### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 
 `memo-mcp` is an MCP (Model Context Protocol) server that enables agents to record, search, and retrieve memos using [LowDB](https://github.com/typicode/lowdb) as a lightweight local database.
 
+<a href="https://glama.ai/mcp/servers/@108yen/memo-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@108yen/memo-mcp/badge" alt="memo-mcp MCP server" />
+</a>
+
 This server stores memo contents in a local JSON file and provides comprehensive memo management functionality including creation, updates, search, and retrieval operations. All data is persisted locally using LowDB, making it ideal for personal memo management without requiring external database dependencies.
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 [![codecov](https://codecov.io/gh/108yen/memo-mcp/graph/badge.svg?token=7C4VJLGXX9)](https://codecov.io/gh/108yen/memo-mcp)
 [![MIT License](https://img.shields.io/github/license/108yen/memo-mcp)](https://img.shields.io/github/license/108yen/memo-mcp)
 
-`memo-mcp` is an MCP (Model Context Protocol) server that enables agents to record, search, and retrieve memos using [LowDB](https://github.com/typicode/lowdb) as a lightweight local database.
-
 <a href="https://glama.ai/mcp/servers/@108yen/memo-mcp">
   <img width="380" height="200" src="https://glama.ai/mcp/servers/@108yen/memo-mcp/badge" alt="memo-mcp MCP server" />
 </a>
+
+`memo-mcp` is an MCP (Model Context Protocol) server that enables agents to record, search, and retrieve memos using [LowDB](https://github.com/typicode/lowdb) as a lightweight local database.
 
 This server stores memo contents in a local JSON file and provides comprehensive memo management functionality including creation, updates, search, and retrieval operations. All data is persisted locally using LowDB, making it ideal for personal memo management without requiring external database dependencies.
 


### PR DESCRIPTION
This PR adds a badge for the [memo-mcp](https://glama.ai/mcp/servers/@108yen/memo-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@108yen/memo-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@108yen/memo-mcp/badge" alt="memo-mcp MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.